### PR TITLE
Prevent memory leak in long-running tabs

### DIFF
--- a/content.js
+++ b/content.js
@@ -51,6 +51,7 @@ function updateStatusControls() {
 }
 
 // main
-(function() {
-  setInterval(updateStatusControls, 1000)
+(function run() {
+  updateStatusControls()
+  setTimeout(run, 1000)
 })();

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Pivotal Tracker Total Selected Points",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Display the sum of the points that you have selected in Pivotal Tracker",
   "manifest_version": 2,
   "content_scripts": [{


### PR DESCRIPTION
- Call `updateStatusControls` in a blocking manner inside main `run`
  fn which uses setTimeout which will only fire once rather than
  flooding the event queue with calls that could, over time, exceed
  the timeout period resulting in a memory leak.